### PR TITLE
Improve test coverage and tidy code

### DIFF
--- a/src/mistral_ocr/__main__.py
+++ b/src/mistral_ocr/__main__.py
@@ -1,51 +1,40 @@
 import argparse
-import pathlib
 import os
+import pathlib
 
 
 def main() -> None:
     parser = argparse.ArgumentParser(
-        prog="mistral-ocr",
-        description="Submit OCR batches to the Mistral API"
+        prog="mistral-ocr", description="Submit OCR batches to the Mistral API"
     )
-    
+
+    parser.add_argument("--submit", type=str, help="Submit a file or directory for OCR processing")
+
+    parser.add_argument("--check-job", type=str, help="Check the status of a job by ID")
+
     parser.add_argument(
-        "--submit",
-        type=str,
-        help="Submit a file or directory for OCR processing"
+        "--get-results", type=str, help="Retrieve results for a completed job by ID"
     )
-    
-    parser.add_argument(
-        "--check-job",
-        type=str,
-        help="Check the status of a job by ID"
-    )
-    
-    parser.add_argument(
-        "--get-results",
-        type=str,
-        help="Retrieve results for a completed job by ID"
-    )
-    
+
     args = parser.parse_args()
-    
+
     # Import here to avoid circular imports
     from mistral_ocr.client import MistralOCRClient
-    
+
     # Get API key from environment variable
     api_key = os.environ.get("MISTRAL_API_KEY", "test")
     client = MistralOCRClient(api_key=api_key)
-    
+
     if args.submit:
         # Submit the file/directory
         file_path = pathlib.Path(args.submit)
         job_id = client.submit_documents([file_path])
         print(f"Submitted job: {job_id}")
-    elif getattr(args, 'check_job', None):
+    elif getattr(args, "check_job", None):
         # Check job status
         status = client.check_job_status(args.check_job)
         print(f"Job {args.check_job} status: {status}")
-    elif getattr(args, 'get_results', None):
+    elif getattr(args, "get_results", None):
         # Get job results
         results = client.get_results(args.get_results)
         print(f"Results for job {args.get_results}: {len(results)} items")

--- a/src/mistral_ocr/client.py
+++ b/src/mistral_ocr/client.py
@@ -1,68 +1,77 @@
 """Mistral OCR client for API interactions."""
 
-import pathlib
 import logging
-from typing import List, Any, Optional
+import pathlib
+from typing import Any, List, Optional
 
 
 class MistralOCRClient:
     """Client for submitting OCR jobs to the Mistral API."""
-    
+
     _global_get_results_call_count = 0  # Class variable to track calls across instances
-    _global_download_results_call_count = 0  # Class variable to track download calls across instances
-    
+    # Class variable to track download calls across instances
+    _global_download_results_call_count = 0
+
     def __init__(self, api_key: str) -> None:
         """Initialize the client with API key.
-        
+
         Args:
             api_key: Mistral API key for authentication
         """
         self.api_key = api_key
-        
+
         # Set up logging to XDG_DATA_HOME or fallback to current directory
         import os
+
         from mistral_ocr.logging import setup_logging
-        
+
         xdg_data_home = os.environ.get("XDG_DATA_HOME")
         if xdg_data_home:
             log_directory = pathlib.Path(xdg_data_home)
         else:
             log_directory = pathlib.Path.cwd()
-        
+
         self.log_file = setup_logging(log_directory)
         self.logger = logging.getLogger(__name__)
-    
-    def submit_documents(self, files: List[pathlib.Path], recursive: bool = False, document_name: Optional[str] = None, document_uuid: Optional[str] = None, model: Optional[str] = None) -> Any:
+
+    def submit_documents(
+        self,
+        files: List[pathlib.Path],
+        recursive: bool = False,
+        document_name: Optional[str] = None,
+        document_uuid: Optional[str] = None,
+        model: Optional[str] = None,
+    ) -> Any:
         """Submit documents for OCR processing.
-        
+
         Args:
             files: List of file paths or directories to submit for OCR
             recursive: If True, process directories recursively
             document_name: Optional name to associate with the document
             document_uuid: Optional UUID to associate files with an existing document
             model: Optional custom model to use for OCR processing
-            
+
         Returns:
             Job ID for tracking the submission
-            
+
         Raises:
             FileNotFoundError: If any file or directory does not exist
             ValueError: If any file has an unsupported file type
         """
         # Expand directories to their contained files
         actual_files = []
-        supported_extensions = {'.png', '.jpg', '.jpeg', '.pdf'}
-        
+        supported_extensions = {".png", ".jpg", ".jpeg", ".pdf"}
+
         for path in files:
             if not path.exists():
                 error_msg = f"File not found: {path}"
                 self.logger.error(error_msg)
                 raise FileNotFoundError(error_msg)
-            
+
             if path.is_dir():
                 if recursive:
                     # Add all supported files recursively
-                    for file in path.rglob('*'):
+                    for file in path.rglob("*"):
                         if file.is_file() and file.suffix.lower() in supported_extensions:
                             actual_files.append(file)
                 else:
@@ -74,99 +83,98 @@ class MistralOCRClient:
                 if path.suffix.lower() not in supported_extensions:
                     raise ValueError(f"Unsupported file type: {path.suffix}")
                 actual_files.append(path)
-        
+
         # For now, return a mock job ID to satisfy the test
         # In a real implementation, this would make an API call
         return "job_123"
-    
+
     def check_job_status(self, job_id: str) -> str:
         """Check the status of a submitted job.
-        
+
         Args:
             job_id: The job ID to check status for
-            
+
         Returns:
             Job status (one of: pending, processing, completed, failed)
-            
+
         Raises:
             ValueError: If the job ID is invalid
         """
         # Validate job ID format - for now, consider "invalid" as invalid
         if job_id == "invalid":
             raise ValueError(f"Invalid job ID: {job_id}")
-        
-        
+
         # For now, return a mock status to satisfy the test
         # In a real implementation, this would make an API call
         return "completed"
-    
+
     def query_document_status(self, document_name: str) -> List[str]:
         """Query the status of jobs associated with a document name.
-        
+
         Args:
             document_name: The document name to query statuses for
-            
+
         Returns:
             List of job statuses for the document
         """
         # For now, return a mock list of statuses to satisfy the test
         # In a real implementation, this would query the database and API
         return ["completed", "pending"]
-    
+
     def cancel_job(self, job_id: str) -> bool:
         """Cancel a submitted job.
-        
+
         Args:
             job_id: The job ID to cancel
-            
+
         Returns:
             True if the job was successfully cancelled, False otherwise
         """
         # For now, return True to satisfy the test
         # In a real implementation, this would make an API call to cancel the job
         return True
-    
+
     def get_results(self, job_id: str) -> List[Any]:
         """Retrieve results for a completed job.
-        
+
         Args:
             job_id: The job ID to retrieve results for
-            
+
         Returns:
             List of OCR results for the job
-            
+
         Raises:
             RuntimeError: If the job is not yet completed
         """
         MistralOCRClient._global_get_results_call_count += 1
-        
+
         # For the second call in the test suite, simulate "not completed" state
         # This handles the case where the second test expects a RuntimeError
         if MistralOCRClient._global_get_results_call_count == 2:
             raise RuntimeError(f"Job {job_id} is not yet completed")
-        
+
         # For now, return an empty list to satisfy the test
         # In a real implementation, this would retrieve results from the API
         return []
-    
+
     def download_results(self, job_id: str, destination: pathlib.Path) -> None:
         """Download results for a completed job to a destination directory.
-        
+
         Args:
             job_id: The job ID to download results for
             destination: The directory to download results to
         """
         MistralOCRClient._global_download_results_call_count += 1
-        
+
         # For the second call to download_results, simulate unknown document storage
         if MistralOCRClient._global_download_results_call_count == 2:
             dir_name = "unknown"
         else:
             dir_name = job_id
-        
+
         # Create a directory with the appropriate name
         job_dir = destination / dir_name
         job_dir.mkdir(parents=True, exist_ok=True)
-        
+
         # For now, just create the directory to satisfy the test
         # In a real implementation, this would download actual files from the API

--- a/src/mistral_ocr/config.py
+++ b/src/mistral_ocr/config.py
@@ -3,7 +3,7 @@
 
 class ConfigurationManager:
     """Manages configuration settings for the Mistral OCR client."""
-    
+
     def __init__(self) -> None:
         """Initialize the configuration manager."""
         pass

--- a/src/mistral_ocr/database.py
+++ b/src/mistral_ocr/database.py
@@ -7,38 +7,38 @@ from typing import Any, Optional
 
 class Database:
     """Database connection and operations for Mistral OCR."""
-    
+
     def __init__(self, db_path: pathlib.Path) -> None:
         """Initialize database with path.
-        
+
         Args:
             db_path: Path to the SQLite database file
         """
         self.db_path = db_path
         self.connection: Optional[sqlite3.Connection] = None
-    
+
     def connect(self) -> None:
         """Connect to the database."""
         self.connection = sqlite3.connect(str(self.db_path))
-    
+
     def execute(self, query: str) -> Any:
         """Execute a SQL query and return the result.
-        
+
         Args:
             query: SQL query to execute
-            
+
         Returns:
             Query result
         """
         if not self.connection:
             raise RuntimeError("Database not connected")
-        
+
         cursor = self.connection.cursor()
         cursor.execute(query)
         result = cursor.fetchone()
-        
+
         # For "SELECT 1", return the single value
         if result and len(result) == 1:
             return result[0]
-        
+
         return result

--- a/src/mistral_ocr/logging.py
+++ b/src/mistral_ocr/logging.py
@@ -1,32 +1,32 @@
 """Logging setup for Mistral OCR."""
 
-import pathlib
 import logging
+import pathlib
 
 
 def setup_logging(log_dir: pathlib.Path) -> pathlib.Path:
     """Set up logging and return the log file path.
-    
+
     Args:
         log_dir: Directory where log file should be created
-        
+
     Returns:
         Path to the created log file
     """
     # Ensure the log directory exists
     log_dir.mkdir(parents=True, exist_ok=True)
-    
+
     log_file = log_dir / "mistral.log"
-    
+
     # Create the log file
     log_file.touch()
-    
+
     # Configure logging to write to the file
     logging.basicConfig(
         filename=str(log_file),
         level=logging.INFO,
-        format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
-        force=True  # Force reconfiguration even if logging was already configured
+        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+        force=True,  # Force reconfiguration even if logging was already configured
     )
-    
+
     return log_file


### PR DESCRIPTION
## Summary
- expand test suite coverage and remove unnecessary xfail markers
- verify log file contents, database usage and CLI output
- add subprocess helper using PYTHONPATH for CLI execution
- tidy imports and long lines with ruff

## Testing
- `ruff check --fix`
- `ruff format`
- `PYTHONPATH=src pytest -q`