### PR TITLE
Add downloads table for result storage

### DIFF
--- a/src/mistral_ocr/db_models.py
+++ b/src/mistral_ocr/db_models.py
@@ -28,6 +28,7 @@ class Document(Base):
     # Relationships
     jobs: Mapped[list["Job"]] = relationship("Job", back_populates="document")
     pages: Mapped[list["Page"]] = relationship("Page", back_populates="document")
+    downloads: Mapped[list["Download"]] = relationship("Download", back_populates="document")
 
 
 class Job(Base):
@@ -36,9 +37,7 @@ class Job(Base):
     __tablename__ = "jobs"
 
     job_id: Mapped[str] = mapped_column(String, primary_key=True)
-    document_uuid: Mapped[str] = mapped_column(
-        String, ForeignKey("documents.uuid"), nullable=False
-    )
+    document_uuid: Mapped[str] = mapped_column(String, ForeignKey("documents.uuid"), nullable=False)
     status: Mapped[str] = mapped_column(String, nullable=False)
     file_count: Mapped[Optional[int]] = mapped_column(Integer)
     created_at: Mapped[datetime] = mapped_column(
@@ -59,6 +58,7 @@ class Job(Base):
 
     # Relationships
     document: Mapped[Document] = relationship("Document", back_populates="jobs")
+    downloads: Mapped[list["Download"]] = relationship("Download", back_populates="job")
 
 
 class Page(Base):
@@ -68,9 +68,7 @@ class Page(Base):
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
     file_path: Mapped[str] = mapped_column(String, nullable=False)
-    document_uuid: Mapped[str] = mapped_column(
-        String, ForeignKey("documents.uuid"), nullable=False
-    )
+    document_uuid: Mapped[str] = mapped_column(String, ForeignKey("documents.uuid"), nullable=False)
     file_id: Mapped[str] = mapped_column(String, nullable=False)
     created_at: Mapped[datetime] = mapped_column(
         DateTime, nullable=False, server_default=func.current_timestamp()
@@ -78,3 +76,23 @@ class Page(Base):
 
     # Relationships
     document: Mapped[Document] = relationship("Document", back_populates="pages")
+
+
+class Download(Base):
+    """Downloaded file record."""
+
+    __tablename__ = "downloads"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    document_uuid: Mapped[str] = mapped_column(String, ForeignKey("documents.uuid"), nullable=False)
+    job_id: Mapped[str] = mapped_column(String, ForeignKey("jobs.job_id"), nullable=False)
+    document_order: Mapped[int] = mapped_column(Integer, nullable=False)
+    text_path: Mapped[str] = mapped_column(String, nullable=False)
+    markdown_path: Mapped[str] = mapped_column(String, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime, nullable=False, server_default=func.current_timestamp()
+    )
+
+    # Relationships
+    document: Mapped[Document] = relationship("Document", back_populates="downloads")
+    job: Mapped[Job] = relationship("Job", back_populates="downloads")

--- a/src/mistral_ocr/result_manager.py
+++ b/src/mistral_ocr/result_manager.py
@@ -231,6 +231,15 @@ class ResultManager:
                 text_file = job_dir / f"{result.file_name}_{i:03d}.txt"
                 FileIOUtils.write_text_file(text_file, result.text)
 
+                if doc_info:
+                    self.database.store_download(
+                        text_path=str(text_file),
+                        markdown_path=str(output_file),
+                        document_uuid=doc_info[0],
+                        job_id=job_id,
+                        document_order=i,
+                    )
+
             self.logger.info(f"Downloaded {len(results)} results to {job_dir}")
 
         except Exception as e:


### PR DESCRIPTION
## Summary
- extend database schema with `downloads` table to track downloaded files
- record text and markdown paths along with document order
- expose `store_download` helper in database layer
- save download metadata in `ResultManager`
- add unit test for new storage method

## Testing
- `ruff format`
- `ruff check` *(fails: Found 35 errors)*
- `mypy src/` *(fails: Found 158 errors)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'mistral_ocr')*