### PR TITLE
Fix ruff issues in tests

### DIFF
--- a/tests/integration/test_error_handling.py
+++ b/tests/integration/test_error_handling.py
@@ -582,7 +582,7 @@ class TestAPIRateLimiting:
 
             for job_id in job_ids:
                 try:
-                    status = client.check_job_status(job_id)
+                    client.check_job_status(job_id)
                     successful_checks += 1
                 except JobError:
                     failed_checks += 1

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -122,14 +122,14 @@ class TestCompleteOCRWorkflow:
         # Create first batch
         job_id_1 = client.submit_documents([test_files[0]], document_name="Shared Document")
 
-        # Get the document UUID from the job details
-        details_1 = client.get_job_details(job_id_1)
+        # Ensure job details are retrievable
+        client.get_job_details(job_id_1)
 
         # Create second batch using the same document name (should associate with same document)
         job_id_2 = client.submit_documents([test_files[1]], document_name="Shared Document")
 
         # Both jobs should be associated with the same document
-        details_2 = client.get_job_details(job_id_2)
+        client.get_job_details(job_id_2)
 
         # Query document status should return both job statuses
         doc_statuses = client.query_document_status("Shared Document")
@@ -169,7 +169,7 @@ class TestCompleteOCRWorkflow:
         if client.mock_mode:
             # Mock mode may not raise for non-existent jobs due to implementation
             try:
-                results = client.get_results("non-existent-job-id")
+                client.get_results("non-existent-job-id")
                 # If it doesn't raise, that's also valid behavior for mock mode
             except Exception:
                 # If it raises any exception, that's also valid
@@ -250,7 +250,7 @@ class TestBatchProcessingWorkflow:
     def test_batch_status_tracking(self, client, large_file_set):
         """Test status tracking across multiple batches."""
         # Submit files that will create multiple batches
-        result = client.submit_documents(large_file_set[:50], document_name="Batch Status Test")
+        client.submit_documents(large_file_set[:50], document_name="Batch Status Test")
 
         # Get all jobs for the document
         doc_statuses = client.query_document_status("Batch Status Test")

--- a/tests/unit/test_cli_subcommands.py
+++ b/tests/unit/test_cli_subcommands.py
@@ -32,7 +32,7 @@ class TestCLISubcommands:
         """Test that main help shows available subcommands."""
         result = run_cli("--help")
         assert result.returncode == 0
-        
+
         # Check for main subcommands
         assert "submit" in result.stdout
         assert "jobs" in result.stdout
@@ -44,7 +44,7 @@ class TestCLISubcommands:
         """Test submit subcommand help."""
         result = run_cli("submit", "--help")
         assert result.returncode == 0
-        
+
         # Check for submit-specific options
         assert "path" in result.stdout.lower()
         assert "--recursive" in result.stdout
@@ -56,7 +56,7 @@ class TestCLISubcommands:
         """Test jobs subcommand help."""
         result = run_cli("jobs", "--help")
         assert result.returncode == 0
-        
+
         # Check for jobs sub-subcommands
         assert "list" in result.stdout
         assert "status" in result.stdout
@@ -66,7 +66,7 @@ class TestCLISubcommands:
         """Test jobs status subcommand help."""
         result = run_cli("jobs", "status", "--help")
         assert result.returncode == 0
-        
+
         # Check for job_id parameter
         assert "job_id" in result.stdout.lower()
 
@@ -74,7 +74,7 @@ class TestCLISubcommands:
         """Test results subcommand help."""
         result = run_cli("results", "--help")
         assert result.returncode == 0
-        
+
         # Check for results sub-subcommands
         assert "get" in result.stdout
         assert "download" in result.stdout
@@ -83,7 +83,7 @@ class TestCLISubcommands:
         """Test results download subcommand help."""
         result = run_cli("results", "download", "--help")
         assert result.returncode == 0
-        
+
         # Check for job_id parameter and output option
         assert "job_id" in result.stdout.lower()
         assert "--output" in result.stdout
@@ -92,7 +92,7 @@ class TestCLISubcommands:
         """Test documents subcommand help."""
         result = run_cli("documents", "--help")
         assert result.returncode == 0
-        
+
         # Check for documents sub-subcommands
         assert "query" in result.stdout
         assert "download" in result.stdout
@@ -101,7 +101,7 @@ class TestCLISubcommands:
         """Test config subcommand help."""
         result = run_cli("config", "--help")
         assert result.returncode == 0
-        
+
         # Check for config sub-subcommands
         assert "show" in result.stdout
         assert "reset" in result.stdout
@@ -111,7 +111,7 @@ class TestCLISubcommands:
         """Test config set subcommand help."""
         result = run_cli("config", "set", "--help")
         assert result.returncode == 0
-        
+
         # Check for configuration keys
         assert "api-key" in result.stdout
         assert "model" in result.stdout
@@ -129,7 +129,7 @@ class TestCLISubcommands:
         result = run_cli("jobs")
         assert result.returncode != 0 or "usage" in result.stdout.lower()
 
-        # Test results without action  
+        # Test results without action
         result = run_cli("results")
         assert result.returncode != 0 or "usage" in result.stdout.lower()
 

--- a/tests/unit/test_logging_infrastructure.py
+++ b/tests/unit/test_logging_infrastructure.py
@@ -4,9 +4,7 @@ import hashlib
 import logging
 import tempfile
 from pathlib import Path
-from unittest.mock import MagicMock, Mock, patch
-
-import pytest
+from unittest.mock import MagicMock, patch
 
 from mistral_ocr.logging import (
     AuditProcessor,
@@ -30,16 +28,12 @@ class TestAuditProcessor:
     def test_audit_processor_adds_audit_trail_marker(self):
         """Test that AuditProcessor adds audit trail markers."""
         processor = AuditProcessor()
-        
+
         # Event with audit markers
-        event_dict = {
-            "event": "Test event",
-            "event_type": "cli_command",
-            "component": "test"
-        }
-        
+        event_dict = {"event": "Test event", "event_type": "cli_command", "component": "test"}
+
         result = processor(None, "info", event_dict)
-        
+
         assert result["audit_trail"] is True
         assert result["event"] == "Test event"
         assert result["event_type"] == "cli_command"
@@ -47,63 +41,52 @@ class TestAuditProcessor:
     def test_audit_processor_security_marker(self):
         """Test audit trail marker for security events."""
         processor = AuditProcessor()
-        
-        event_dict = {
-            "event": "Security event",
-            "security": True,
-            "component": "auth"
-        }
-        
+
+        event_dict = {"event": "Security event", "security": True, "component": "auth"}
+
         result = processor(None, "warning", event_dict)
-        
+
         assert result["audit_trail"] is True
         assert result["security"] is True
 
     def test_audit_processor_performance_marker(self):
         """Test audit trail marker for performance events."""
         processor = AuditProcessor()
-        
+
         event_dict = {
             "event": "Performance event",
             "performance": True,
-            "operation": "batch_processing"
+            "operation": "batch_processing",
         }
-        
+
         result = processor(None, "info", event_dict)
-        
+
         assert result["audit_trail"] is True
         assert result["performance"] is True
 
     def test_audit_processor_no_audit_marker(self):
         """Test that regular events don't get audit trail marker."""
         processor = AuditProcessor()
-        
-        event_dict = {
-            "event": "Regular event",
-            "component": "test"
-        }
-        
+
+        event_dict = {"event": "Regular event", "component": "test"}
+
         result = processor(None, "info", event_dict)
-        
+
         assert "audit_trail" not in result
         assert result["event"] == "Regular event"
 
     def test_audit_processor_api_key_sanitization(self):
         """Test API key sanitization in audit processor."""
         processor = AuditProcessor()
-        
+
         api_key = "sk-test-api-key-12345"
-        event_dict = {
-            "event": "API call",
-            "api_key": api_key,
-            "operation": "authentication"
-        }
-        
+        event_dict = {"event": "API call", "api_key": api_key, "operation": "authentication"}
+
         result = processor(None, "info", event_dict)
-        
+
         # API key should be removed
         assert "api_key" not in result
-        
+
         # Should have hash instead
         assert "api_key_hash" in result
         expected_hash = hashlib.sha256(api_key.encode()).hexdigest()[:16]
@@ -112,15 +95,11 @@ class TestAuditProcessor:
     def test_audit_processor_empty_api_key(self):
         """Test handling of empty API key."""
         processor = AuditProcessor()
-        
-        event_dict = {
-            "event": "API call",
-            "api_key": "",
-            "operation": "authentication"
-        }
-        
+
+        event_dict = {"event": "API call", "api_key": "", "operation": "authentication"}
+
         result = processor(None, "info", event_dict)
-        
+
         # Empty API key should be removed without adding hash
         assert "api_key" not in result
         assert "api_key_hash" not in result
@@ -128,15 +107,11 @@ class TestAuditProcessor:
     def test_audit_processor_none_api_key(self):
         """Test handling of None API key."""
         processor = AuditProcessor()
-        
-        event_dict = {
-            "event": "API call",
-            "api_key": None,
-            "operation": "authentication"
-        }
-        
+
+        event_dict = {"event": "API call", "api_key": None, "operation": "authentication"}
+
         result = processor(None, "info", event_dict)
-        
+
         # None API key should be removed without adding hash
         assert "api_key" not in result
         assert "api_key_hash" not in result
@@ -144,7 +119,7 @@ class TestAuditProcessor:
     def test_audit_processor_preserves_other_fields(self):
         """Test that processor preserves other fields."""
         processor = AuditProcessor()
-        
+
         event_dict = {
             "event": "Test event",
             "event_type": "data_processing",
@@ -152,11 +127,11 @@ class TestAuditProcessor:
             "user_id": "user123",
             "operation": "file_upload",
             "duration": 2.5,
-            "file_count": 10
+            "file_count": 10,
         }
-        
+
         result = processor(None, "info", event_dict)
-        
+
         # All fields except api_key should be preserved
         assert result["event"] == "Test event"
         assert result["event_type"] == "data_processing"
@@ -176,9 +151,9 @@ class TestSetupLogging:
         with tempfile.TemporaryDirectory() as temp_dir:
             log_dir = Path(temp_dir) / "logs"
             assert not log_dir.exists()
-            
+
             setup_logging(log_dir)
-            
+
             assert log_dir.exists()
             assert log_dir.is_dir()
 
@@ -186,17 +161,17 @@ class TestSetupLogging:
         """Test that setup_logging creates required log files."""
         with tempfile.TemporaryDirectory() as temp_dir:
             log_dir = Path(temp_dir) / "logs"
-            
+
             setup_logging(log_dir)
-            
+
             # Main log file should be created
             main_log = log_dir / "mistral.log"
             assert main_log.exists()
-            
+
             # Audit log file should be created
             audit_log = log_dir / "audit.log"
             assert audit_log.exists()
-            
+
             # Performance log file should be created
             perf_log = log_dir / "performance.log"
             assert perf_log.exists()
@@ -205,9 +180,9 @@ class TestSetupLogging:
         """Test that setup_logging returns the main log file path."""
         with tempfile.TemporaryDirectory() as temp_dir:
             log_dir = Path(temp_dir) / "logs"
-            
+
             result = setup_logging(log_dir)
-            
+
             expected_path = log_dir / "mistral.log"
             assert result == expected_path
 
@@ -215,9 +190,9 @@ class TestSetupLogging:
         """Test setup_logging with custom log level."""
         with tempfile.TemporaryDirectory() as temp_dir:
             log_dir = Path(temp_dir) / "logs"
-            
+
             setup_logging(log_dir, level="DEBUG")
-            
+
             # Should configure logging at DEBUG level
             assert logging.getLogger().level == logging.DEBUG
 
@@ -225,12 +200,12 @@ class TestSetupLogging:
         """Test setup_logging with custom rotation settings."""
         with tempfile.TemporaryDirectory() as temp_dir:
             log_dir = Path(temp_dir) / "logs"
-            
+
             max_bytes = 10 * 1024 * 1024  # 10MB
             backup_count = 3
-            
+
             setup_logging(log_dir, max_bytes=max_bytes, backup_count=backup_count)
-            
+
             # Log files should be created
             main_log = log_dir / "mistral.log"
             assert main_log.exists()
@@ -239,78 +214,78 @@ class TestSetupLogging:
         """Test setup_logging with console output enabled."""
         with tempfile.TemporaryDirectory() as temp_dir:
             log_dir = Path(temp_dir) / "logs"
-            
-            with patch('mistral_ocr.logging.logging.basicConfig') as mock_config:
+
+            with patch("mistral_ocr.logging.logging.basicConfig") as mock_config:
                 setup_logging(log_dir, enable_console=True)
-                
+
                 # Should configure console handler
                 mock_config.assert_called_once()
                 call_kwargs = mock_config.call_args[1]
-                assert len(call_kwargs['handlers']) == 2  # File + Console
+                assert len(call_kwargs["handlers"]) == 2  # File + Console
 
     def test_setup_logging_console_disabled(self):
         """Test setup_logging with console output disabled."""
         with tempfile.TemporaryDirectory() as temp_dir:
             log_dir = Path(temp_dir) / "logs"
-            
-            with patch('mistral_ocr.logging.logging.basicConfig') as mock_config:
+
+            with patch("mistral_ocr.logging.logging.basicConfig") as mock_config:
                 setup_logging(log_dir, enable_console=False)
-                
+
                 # Should only configure file handler
                 mock_config.assert_called_once()
                 call_kwargs = mock_config.call_args[1]
-                assert len(call_kwargs['handlers']) == 1  # File only
+                assert len(call_kwargs["handlers"]) == 1  # File only
 
-    @patch('mistral_ocr.logging.structlog.configure')
+    @patch("mistral_ocr.logging.structlog.configure")
     def test_setup_logging_configures_structlog(self, mock_configure):
         """Test that setup_logging configures structlog."""
         with tempfile.TemporaryDirectory() as temp_dir:
             log_dir = Path(temp_dir) / "logs"
-            
+
             setup_logging(log_dir)
-            
+
             # Should configure structlog
             mock_configure.assert_called_once()
             call_kwargs = mock_configure.call_args[1]
-            assert 'processors' in call_kwargs
-            assert 'wrapper_class' in call_kwargs
-            assert 'logger_factory' in call_kwargs
+            assert "processors" in call_kwargs
+            assert "wrapper_class" in call_kwargs
+            assert "logger_factory" in call_kwargs
 
-    @patch('sys.stderr.isatty', return_value=True)
-    @patch('mistral_ocr.logging.structlog.configure')
+    @patch("sys.stderr.isatty", return_value=True)
+    @patch("mistral_ocr.logging.structlog.configure")
     def test_setup_logging_console_processors_for_tty(self, mock_configure, mock_isatty):
         """Test that console processors are used for TTY."""
         with tempfile.TemporaryDirectory() as temp_dir:
             log_dir = Path(temp_dir) / "logs"
-            
+
             setup_logging(log_dir, enable_console=True)
-            
+
             # Should use console processors for TTY
             mock_configure.assert_called_once()
             call_kwargs = mock_configure.call_args[1]
-            processors = call_kwargs['processors']
-            
+            processors = call_kwargs["processors"]
+
             # Should include ConsoleRenderer
             processor_types = [type(p).__name__ for p in processors]
-            assert 'ConsoleRenderer' in processor_types
+            assert "ConsoleRenderer" in processor_types
 
-    @patch('sys.stderr.isatty', return_value=False)
-    @patch('mistral_ocr.logging.structlog.configure')
+    @patch("sys.stderr.isatty", return_value=False)
+    @patch("mistral_ocr.logging.structlog.configure")
     def test_setup_logging_json_processors_for_non_tty(self, mock_configure, mock_isatty):
         """Test that JSON processors are used for non-TTY."""
         with tempfile.TemporaryDirectory() as temp_dir:
             log_dir = Path(temp_dir) / "logs"
-            
+
             setup_logging(log_dir, enable_console=True)
-            
+
             # Should use JSON processors for non-TTY
             mock_configure.assert_called_once()
             call_kwargs = mock_configure.call_args[1]
-            processors = call_kwargs['processors']
-            
+            processors = call_kwargs["processors"]
+
             # Should include JSONRenderer
             processor_types = [type(p).__name__ for p in processors]
-            assert 'JSONRenderer' in processor_types
+            assert "JSONRenderer" in processor_types
 
 
 class TestSetupAuditLogging:
@@ -321,9 +296,9 @@ class TestSetupAuditLogging:
         with tempfile.TemporaryDirectory() as temp_dir:
             log_dir = Path(temp_dir) / "audit_logs"
             assert not log_dir.exists()
-            
+
             setup_audit_logging(log_dir)
-            
+
             assert log_dir.exists()
             assert log_dir.is_dir()
 
@@ -331,16 +306,16 @@ class TestSetupAuditLogging:
         """Test that setup_audit_logging creates all required files."""
         with tempfile.TemporaryDirectory() as temp_dir:
             log_dir = Path(temp_dir) / "audit_logs"
-            
+
             result = setup_audit_logging(log_dir)
-            
+
             # Should return dictionary with all log file paths
             assert isinstance(result, dict)
-            assert 'audit' in result
-            assert 'security' in result
-            assert 'performance' in result
-            assert 'api' in result
-            
+            assert "audit" in result
+            assert "security" in result
+            assert "performance" in result
+            assert "api" in result
+
             # All files should be created
             for log_type, log_path in result.items():
                 assert log_path.exists()
@@ -350,38 +325,38 @@ class TestSetupAuditLogging:
         """Test that setup_audit_logging returns correct file paths."""
         with tempfile.TemporaryDirectory() as temp_dir:
             log_dir = Path(temp_dir) / "audit_logs"
-            
+
             result = setup_audit_logging(log_dir)
-            
-            assert result['audit'] == log_dir / "audit.log"
-            assert result['security'] == log_dir / "security.log"
-            assert result['performance'] == log_dir / "performance.log"
-            assert result['api'] == log_dir / "api.log"
+
+            assert result["audit"] == log_dir / "audit.log"
+            assert result["security"] == log_dir / "security.log"
+            assert result["performance"] == log_dir / "performance.log"
+            assert result["api"] == log_dir / "api.log"
 
 
 class TestGetLogger:
     """Test the get_logger function."""
 
-    @patch('mistral_ocr.logging.structlog.get_logger')
+    @patch("mistral_ocr.logging.structlog.get_logger")
     def test_get_logger_calls_structlog(self, mock_get_logger):
         """Test that get_logger calls structlog.get_logger."""
         mock_logger = MagicMock()
         mock_get_logger.return_value = mock_logger
-        
+
         result = get_logger("test_component")
-        
+
         mock_get_logger.assert_called_once_with("test_component")
         assert result == mock_logger
 
     def test_get_logger_returns_logger_instance(self):
         """Test that get_logger returns a logger instance."""
         logger = get_logger("test_component")
-        
+
         # Should have logger methods
-        assert hasattr(logger, 'info')
-        assert hasattr(logger, 'debug')
-        assert hasattr(logger, 'warning')
-        assert hasattr(logger, 'error')
+        assert hasattr(logger, "info")
+        assert hasattr(logger, "debug")
+        assert hasattr(logger, "warning")
+        assert hasattr(logger, "error")
 
 
 class TestLogPathHelpers:
@@ -391,80 +366,80 @@ class TestLogPathHelpers:
         """Test get_audit_log_path function."""
         with tempfile.TemporaryDirectory() as temp_dir:
             log_dir = Path(temp_dir) / "logs"
-            
+
             result = get_audit_log_path(log_dir)
-            
+
             assert result == log_dir / "audit.log"
 
     def test_get_performance_log_path(self):
         """Test get_performance_log_path function."""
         with tempfile.TemporaryDirectory() as temp_dir:
             log_dir = Path(temp_dir) / "logs"
-            
+
             result = get_performance_log_path(log_dir)
-            
+
             assert result == log_dir / "performance.log"
 
 
 class TestConfigureLogLevel:
     """Test the configure_log_level function."""
 
-    @patch('mistral_ocr.logging.structlog.configure')
-    @patch('mistral_ocr.logging.logging.getLogger')
+    @patch("mistral_ocr.logging.structlog.configure")
+    @patch("mistral_ocr.logging.logging.getLogger")
     def test_configure_log_level_debug(self, mock_get_logger, mock_configure):
         """Test configuring log level to DEBUG."""
         mock_logger = MagicMock()
         mock_get_logger.return_value = mock_logger
-        
+
         configure_log_level("DEBUG")
-        
+
         # Should configure structlog
         mock_configure.assert_called_once()
-        
+
         # Should set Python logging level
         mock_logger.setLevel.assert_called_once_with(logging.DEBUG)
 
-    @patch('mistral_ocr.logging.structlog.configure')
-    @patch('mistral_ocr.logging.logging.getLogger')
+    @patch("mistral_ocr.logging.structlog.configure")
+    @patch("mistral_ocr.logging.logging.getLogger")
     def test_configure_log_level_info(self, mock_get_logger, mock_configure):
         """Test configuring log level to INFO."""
         mock_logger = MagicMock()
         mock_get_logger.return_value = mock_logger
-        
+
         configure_log_level("INFO")
-        
+
         mock_logger.setLevel.assert_called_once_with(logging.INFO)
 
-    @patch('mistral_ocr.logging.structlog.configure')
-    @patch('mistral_ocr.logging.logging.getLogger')
+    @patch("mistral_ocr.logging.structlog.configure")
+    @patch("mistral_ocr.logging.logging.getLogger")
     def test_configure_log_level_warning(self, mock_get_logger, mock_configure):
         """Test configuring log level to WARNING."""
         mock_logger = MagicMock()
         mock_get_logger.return_value = mock_logger
-        
+
         configure_log_level("WARNING")
-        
+
         mock_logger.setLevel.assert_called_once_with(logging.WARNING)
 
-    @patch('mistral_ocr.logging.structlog.configure')
-    @patch('mistral_ocr.logging.logging.getLogger')
+    @patch("mistral_ocr.logging.structlog.configure")
+    @patch("mistral_ocr.logging.logging.getLogger")
     def test_configure_log_level_error(self, mock_get_logger, mock_configure):
         """Test configuring log level to ERROR."""
         mock_logger = MagicMock()
         mock_get_logger.return_value = mock_logger
-        
+
         configure_log_level("ERROR")
-        
+
         mock_logger.setLevel.assert_called_once_with(logging.ERROR)
 
-    @patch('mistral_ocr.logging.structlog.configure')
+    @patch("mistral_ocr.logging.structlog.configure")
     def test_configure_log_level_updates_structlog_wrapper(self, mock_configure):
         """Test that configure_log_level updates structlog wrapper class."""
         configure_log_level("WARNING")
-        
+
         mock_configure.assert_called_once()
         call_kwargs = mock_configure.call_args[1]
-        assert 'wrapper_class' in call_kwargs
+        assert "wrapper_class" in call_kwargs
 
 
 class TestLoggingIntegration:
@@ -474,22 +449,22 @@ class TestLoggingIntegration:
         """Test complete logging setup workflow."""
         with tempfile.TemporaryDirectory() as temp_dir:
             log_dir = Path(temp_dir) / "integration_logs"
-            
+
             # Setup main logging
             main_log_path = setup_logging(log_dir, level="DEBUG")
-            
+
             # Setup audit logging
             audit_paths = setup_audit_logging(log_dir)
-            
+
             # Get a logger and test it
             logger = get_logger("integration_test")
-            
+
             # Log messages at different levels
             logger.debug("Debug message")
             logger.info("Info message")
             logger.warning("Warning message")
             logger.error("Error message")
-            
+
             # All log files should exist
             assert main_log_path.exists()
             for audit_path in audit_paths.values():
@@ -498,7 +473,7 @@ class TestLoggingIntegration:
     def test_audit_processor_with_real_event(self):
         """Test AuditProcessor with realistic event data."""
         processor = AuditProcessor()
-        
+
         # Realistic audit event
         event_dict = {
             "event": "User authentication successful",
@@ -508,21 +483,18 @@ class TestLoggingIntegration:
             "api_key": "sk-real-api-key-abcdef",
             "timestamp": "2024-01-01T12:00:00Z",
             "outcome": "success",
-            "details": {
-                "method": "api_key",
-                "source_ip": "192.168.1.100"
-            }
+            "details": {"method": "api_key", "source_ip": "192.168.1.100"},
         }
-        
+
         result = processor(None, "info", event_dict)
-        
+
         # Should add audit trail marker
         assert result["audit_trail"] is True
-        
+
         # Should sanitize API key
         assert "api_key" not in result
         assert "api_key_hash" in result
-        
+
         # Should preserve other fields
         assert result["event"] == "User authentication successful"
         assert result["user_id"] == "user_12345"
@@ -533,14 +505,14 @@ class TestLoggingIntegration:
         """Test that log rotation is properly configured."""
         with tempfile.TemporaryDirectory() as temp_dir:
             log_dir = Path(temp_dir) / "rotation_test"
-            
+
             # Setup with small file size for testing
             setup_logging(
                 log_dir,
                 max_bytes=1024,  # 1KB
-                backup_count=2
+                backup_count=2,
             )
-            
+
             # Log files should be created
             main_log = log_dir / "mistral.log"
             assert main_log.exists()
@@ -550,12 +522,12 @@ class TestLoggingIntegration:
         with tempfile.TemporaryDirectory() as temp_dir:
             log_dir = Path(temp_dir) / "multi_logger_test"
             setup_logging(log_dir)
-            
+
             # Create multiple loggers
             logger1 = get_logger("component1")
             logger2 = get_logger("component2")
             logger3 = get_logger("component3")
-            
+
             # All should be usable
             logger1.info("Message from component1")
             logger2.warning("Message from component2")
@@ -566,9 +538,9 @@ class TestLoggingIntegration:
         with tempfile.TemporaryDirectory() as temp_dir:
             log_dir = Path(temp_dir) / "structured_test"
             setup_logging(log_dir, level="DEBUG")
-            
+
             logger = get_logger("structured_test")
-            
+
             # Log with complex structured data
             logger.info(
                 "Batch processing completed",
@@ -579,11 +551,7 @@ class TestLoggingIntegration:
                     {"name": "file1.pdf", "size": 1024, "status": "success"},
                     {"name": "file2.png", "size": 2048, "status": "success"},
                 ],
-                metadata={
-                    "user_id": "user_789",
-                    "job_type": "ocr_batch",
-                    "priority": "high"
-                }
+                metadata={"user_id": "user_789", "job_type": "ocr_batch", "priority": "high"},
             )
 
     def test_error_handling_in_logging(self):
@@ -591,9 +559,9 @@ class TestLoggingIntegration:
         with tempfile.TemporaryDirectory() as temp_dir:
             log_dir = Path(temp_dir) / "error_test"
             setup_logging(log_dir)
-            
+
             logger = get_logger("error_test")
-            
+
             # Should handle various data types without errors
             logger.info("Test with None", data=None)
             logger.info("Test with empty dict", data={})
@@ -602,17 +570,17 @@ class TestLoggingIntegration:
     def test_performance_of_logging_setup(self):
         """Test that logging setup is performant."""
         import time
-        
+
         start_time = time.time()
-        
+
         with tempfile.TemporaryDirectory() as temp_dir:
             log_dir = Path(temp_dir) / "performance_test"
-            
+
             # Setup logging multiple times
             for i in range(10):
                 setup_logging(log_dir / f"test_{i}")
-        
+
         duration = time.time() - start_time
-        
+
         # Should complete quickly
         assert duration < 2.0  # Less than 2 seconds for 10 setups

--- a/tests/unit/test_progress.py
+++ b/tests/unit/test_progress.py
@@ -6,8 +6,8 @@ from unittest.mock import MagicMock, Mock, patch
 import pytest
 
 from mistral_ocr.progress import (
-    DummyProgress,
     DownloadProgressTracker,
+    DummyProgress,
     LiveJobMonitor,
     ProgressManager,
     SubmissionProgressTracker,
@@ -110,7 +110,7 @@ class TestDummyProgress:
     def test_dummy_progress_task_operations(self):
         """Test that DummyProgress handles task operations gracefully."""
         dummy = DummyProgress()
-        
+
         # Should not raise exceptions for any method calls
         task_id = dummy.add_task("Processing files", total=100)
         dummy.update(task_id, completed=25, description="Processing...")
@@ -162,41 +162,45 @@ class TestSubmissionProgressTracker:
         """Test track_submission context manager setup."""
         file_count = 150
         batch_count = 3
-        
+
         # Mock the manager's create_progress method
-        submission_tracker.manager.create_progress.return_value.__enter__ = Mock(return_value=mock_progress)
+        submission_tracker.manager.create_progress.return_value.__enter__ = Mock(
+            return_value=mock_progress
+        )
         submission_tracker.manager.create_progress.return_value.__exit__ = Mock(return_value=None)
-        
+
         with submission_tracker.track_submission(file_count, batch_count) as context:
             # Context should provide methods
-            assert hasattr(context, 'complete_collection')
-            assert hasattr(context, 'update_encoding')
-            assert hasattr(context, 'start_upload')
-            assert hasattr(context, 'complete_upload')
-            assert hasattr(context, 'update_job_creation')
-            assert hasattr(context, 'complete_job_creation')
+            assert hasattr(context, "complete_collection")
+            assert hasattr(context, "update_encoding")
+            assert hasattr(context, "start_upload")
+            assert hasattr(context, "complete_upload")
+            assert hasattr(context, "update_job_creation")
+            assert hasattr(context, "complete_job_creation")
 
     def test_submission_progress_phases(self, submission_tracker, mock_progress):
         """Test all phases of submission progress tracking."""
         # Mock the manager's create_progress method
-        submission_tracker.manager.create_progress.return_value.__enter__ = Mock(return_value=mock_progress)
+        submission_tracker.manager.create_progress.return_value.__enter__ = Mock(
+            return_value=mock_progress
+        )
         submission_tracker.manager.create_progress.return_value.__exit__ = Mock(return_value=None)
-        
+
         with submission_tracker.track_submission(100, 2) as context:
             # Phase 1: Collection
             context.complete_collection(100)
             # Phase 2: Encoding
             context.update_encoding(50)
             # Phase 3: Upload
-            context.start_upload("batch1.jsonl", 1024*1024)
-            
+            context.start_upload("batch1.jsonl", 1024 * 1024)
+
             context.complete_upload("batch1.jsonl")
             mock_progress.update.assert_called()
-            
+
             # Phase 4: Job Creation
             context.update_job_creation(1)
             mock_progress.update.assert_called()
-            
+
             context.complete_job_creation()
             mock_progress.update.assert_called()
 
@@ -205,13 +209,13 @@ class TestSubmissionProgressTracker:
         with submission_tracker.track_submission(200, 3) as context:
             # Multiple uploads for different batches
             for i in range(3):
-                batch_name = f"batch{i+1}.jsonl"
-                context.start_upload(batch_name, 1024*1024)
+                batch_name = f"batch{i + 1}.jsonl"
+                context.start_upload(batch_name, 1024 * 1024)
                 context.complete_upload(batch_name)
-                context.update_job_creation(i+1)
-            
+                context.update_job_creation(i + 1)
+
             context.complete_job_creation()
-            
+
             # Should have multiple update calls
             assert mock_progress.update.call_count >= 6  # 3 starts + 3 completions
 
@@ -259,39 +263,43 @@ class TestDownloadProgressTracker:
         """Test starting a download with progress tracking."""
         job_id = "job_12345"
         file_size = 1024 * 1024  # 1MB
-        
+
         # Mock the manager's create_progress method
-        download_tracker.manager.create_progress.return_value.__enter__ = Mock(return_value=mock_progress)
+        download_tracker.manager.create_progress.return_value.__enter__ = Mock(
+            return_value=mock_progress
+        )
         download_tracker.manager.create_progress.return_value.__exit__ = Mock(return_value=None)
-        
+
         with download_tracker.track_downloads(1) as context:
             context.start_download(job_id, file_size)
-            
+
             # Should add a task for this download
             mock_progress.add_task.assert_called()
             call_args = mock_progress.add_task.call_args
             assert job_id[:8] in call_args[0][0]  # Description should contain job ID
-            assert call_args[1]['total'] == file_size
+            assert call_args[1]["total"] == file_size
 
     def test_update_download(self, download_tracker, mock_progress):
         """Test updating download progress."""
         job_id = "job_12345"
         file_size = 1024 * 1024
-        
+
         # Mock the manager's create_progress method
-        download_tracker.manager.create_progress.return_value.__enter__ = Mock(return_value=mock_progress)
+        download_tracker.manager.create_progress.return_value.__enter__ = Mock(
+            return_value=mock_progress
+        )
         download_tracker.manager.create_progress.return_value.__exit__ = Mock(return_value=None)
-        
+
         # Setup download
         mock_progress.add_task.return_value = "task_id"
-        
+
         with download_tracker.track_downloads(1) as context:
             context.start_download(job_id, file_size)
-            
+
             # Update progress
             downloaded = 512 * 1024  # 512KB
             context.update_download(job_id, downloaded)
-            
+
             # Should update the task
             mock_progress.update.assert_called()
 
@@ -299,62 +307,64 @@ class TestDownloadProgressTracker:
         """Test completing a download."""
         job_id = "job_12345"
         file_size = 1024 * 1024
-        
+
         # Mock the manager's create_progress method
-        download_tracker.manager.create_progress.return_value.__enter__ = Mock(return_value=mock_progress)
+        download_tracker.manager.create_progress.return_value.__enter__ = Mock(
+            return_value=mock_progress
+        )
         download_tracker.manager.create_progress.return_value.__exit__ = Mock(return_value=None)
-        
+
         # Setup download
         mock_progress.add_task.return_value = "task_id"
-        
+
         with download_tracker.track_downloads(1) as context:
             context.start_download(job_id, file_size)
-            
+
             # Complete download
             context.complete_download(job_id)
-            
+
             # Should remove task
             mock_progress.remove_task.assert_called()
 
     def test_multiple_concurrent_downloads(self, download_tracker, mock_progress):
         """Test handling multiple concurrent downloads."""
-        jobs = [
-            ("job_001", 1024),
-            ("job_002", 2048),
-            ("job_003", 512)
-        ]
-        
+        jobs = [("job_001", 1024), ("job_002", 2048), ("job_003", 512)]
+
         # Mock the manager's create_progress method
-        download_tracker.manager.create_progress.return_value.__enter__ = Mock(return_value=mock_progress)
+        download_tracker.manager.create_progress.return_value.__enter__ = Mock(
+            return_value=mock_progress
+        )
         download_tracker.manager.create_progress.return_value.__exit__ = Mock(return_value=None)
-        
+
         with download_tracker.track_downloads(3) as context:
             # Start all downloads
             for job_id, size in jobs:
                 context.start_download(job_id, size)
-            
+
             # Update progress for each
             for job_id, size in jobs:
                 context.update_download(job_id, size // 2)
-            
+
             # Complete all downloads
             for job_id, size in jobs:
                 context.complete_download(job_id)
-            
+
             # Should have created tasks for each file (plus overall task)
             assert mock_progress.add_task.call_count >= 3
 
     def test_unknown_job_operations(self, download_tracker, mock_progress):
         """Test operations on unknown jobs (should handle gracefully)."""
         # Mock the manager's create_progress method
-        download_tracker.manager.create_progress.return_value.__enter__ = Mock(return_value=mock_progress)
+        download_tracker.manager.create_progress.return_value.__enter__ = Mock(
+            return_value=mock_progress
+        )
         download_tracker.manager.create_progress.return_value.__exit__ = Mock(return_value=None)
-        
+
         with download_tracker.track_downloads(1) as context:
             # Update/complete jobs that weren't started
             context.update_download("unknown_job", 1024)
             context.complete_download("unknown_job")
-            
+
             # Should not crash - operations on unknown jobs are handled gracefully
 
 
@@ -399,15 +409,13 @@ class TestLiveJobMonitor:
 
     def test_basic_monitor_setup(self, job_monitor):
         """Test basic job monitor setup."""
-        job_ids = ["job_001", "job_002", "job_003"]
-        
         # Mock the necessary dependencies for monitor_jobs
-        with patch('mistral_ocr.progress.get_settings') as mock_get_settings:
-            with patch('mistral_ocr.progress.MistralOCRClient'):
+        with patch("mistral_ocr.progress.get_settings") as mock_get_settings:
+            with patch("mistral_ocr.progress.MistralOCRClient"):
                 mock_settings = MagicMock()
                 mock_settings.get_api_key_optional.return_value = "test-key"
                 mock_get_settings.return_value = mock_settings
-                
+
                 # Should not raise when monitor is enabled
                 assert job_monitor.manager.enabled
 
@@ -415,7 +423,7 @@ class TestLiveJobMonitor:
         """Test status table creation."""
         job_ids = ["job_001", "job_002"]
         statuses = {"job_001": "running", "job_002": "completed"}
-        
+
         # Should be able to create status table
         table = job_monitor._create_status_table(job_ids, statuses)
         assert table is not None
@@ -423,13 +431,13 @@ class TestLiveJobMonitor:
     def test_status_change_detection(self, job_monitor):
         """Test status change detection."""
         current_statuses = {"job_001": "completed", "job_002": "running"}
-        
+
         # Initialize last statuses
         job_monitor._last_statuses = {"job_001": "running", "job_002": "pending"}
-        
+
         # Should detect changes
         job_monitor._detect_status_changes(current_statuses)
-        
+
         # Last statuses should be updated
         assert job_monitor._last_statuses["job_001"] == "completed"
 
@@ -438,7 +446,7 @@ class TestLiveJobMonitor:
         # All completed
         statuses_complete = {"job_001": "COMPLETED", "job_002": "FAILED"}
         assert job_monitor._all_jobs_complete(statuses_complete)
-        
+
         # Some still running
         statuses_running = {"job_001": "COMPLETED", "job_002": "RUNNING"}
         assert not job_monitor._all_jobs_complete(statuses_running)
@@ -456,17 +464,17 @@ class TestProgressIntegration:
 
     def test_progress_manager_full_workflow(self):
         """Test complete workflow with ProgressManager."""
-        with patch("mistral_ocr.progress.Console") as mock_console:
-            with patch("mistral_ocr.progress.Progress") as mock_progress:
-                with patch("mistral_ocr.progress.Live") as mock_live:
+        with patch("mistral_ocr.progress.Console"):
+            with patch("mistral_ocr.progress.Progress"):
+                with patch("mistral_ocr.progress.Live"):
                     # Create manager
                     manager = ProgressManager(enabled=True)
-                    
+
                     # Create all tracker types
                     submission_tracker = manager.create_submission_progress()
                     download_tracker = manager.create_download_progress()
                     job_monitor = manager.create_job_monitor()
-                    
+
                     # Verify correct types
                     assert isinstance(submission_tracker, SubmissionProgressTracker)
                     assert isinstance(download_tracker, DownloadProgressTracker)
@@ -476,16 +484,16 @@ class TestProgressIntegration:
         """Test that disabled manager creates trackers with disabled managers."""
         with patch("mistral_ocr.progress.Console"):
             manager = ProgressManager(enabled=False)
-            
+
             # All trackers should still be the correct type but with disabled managers
             submission_tracker = manager.create_submission_progress()
             download_tracker = manager.create_download_progress()
             job_monitor = manager.create_job_monitor()
-            
+
             assert isinstance(submission_tracker, SubmissionProgressTracker)
             assert isinstance(download_tracker, DownloadProgressTracker)
             assert isinstance(job_monitor, LiveJobMonitor)
-            
+
             # But their managers should be disabled
             assert not submission_tracker.manager.enabled
             assert not download_tracker.manager.enabled
@@ -494,11 +502,11 @@ class TestProgressIntegration:
     def test_progress_tracking_performance(self):
         """Test that progress tracking doesn't significantly impact performance."""
         start_time = time.time()
-        
+
         # Create multiple progress trackers and simulate work
         with patch("mistral_ocr.progress.Console"):
             manager = ProgressManager(enabled=True)
-            
+
             # Create trackers
             for _ in range(10):
                 tracker = manager.create_submission_progress()
@@ -506,24 +514,24 @@ class TestProgressIntegration:
                     context.complete_collection(100)
                     context.update_encoding(50)
                     context.complete_job_creation()
-        
+
         duration = time.time() - start_time
-        
+
         # Should complete quickly (< 1 second even with overhead)
         assert duration < 1.0
 
     def test_concurrent_progress_tracking(self):
         """Test that multiple progress trackers can work concurrently."""
-        import threading
         import queue
-        
+        import threading
+
         results = queue.Queue()
-        
+
         def track_progress(tracker_id):
             with patch("mistral_ocr.progress.Console"):
                 manager = ProgressManager(enabled=True)
                 tracker = manager.create_submission_progress()
-                
+
                 try:
                     with tracker.track_submission(50, 2) as context:
                         context.complete_collection(50)
@@ -532,23 +540,23 @@ class TestProgressIntegration:
                     results.put((tracker_id, "success"))
                 except Exception as e:
                     results.put((tracker_id, f"error: {e}"))
-        
+
         # Start multiple threads
         threads = []
         for i in range(3):
             thread = threading.Thread(target=track_progress, args=(i,))
             threads.append(thread)
             thread.start()
-        
+
         # Wait for completion
         for thread in threads:
             thread.join()
-        
+
         # Verify all succeeded
         thread_results = []
         while not results.empty():
             thread_results.append(results.get())
-        
+
         assert len(thread_results) == 3
         for tracker_id, result in thread_results:
             assert result == "success"
@@ -557,18 +565,17 @@ class TestProgressIntegration:
         """Test integration with actual Rich components (mocked)."""
         from rich.console import Console
         from rich.progress import Progress
-        from rich.live import Live
-        
+
         # Test with real Rich classes but minimal functionality
-        with patch.object(Console, 'print') as mock_print:
-            with patch.object(Progress, '__enter__', return_value=MagicMock()):
-                with patch.object(Progress, '__exit__', return_value=None):
-                    with patch.object(Progress, 'add_task', return_value="task_id"):
-                        with patch.object(Progress, 'update'):
+        with patch.object(Console, "print"):
+            with patch.object(Progress, "__enter__", return_value=MagicMock()):
+                with patch.object(Progress, "__exit__", return_value=None):
+                    with patch.object(Progress, "add_task", return_value="task_id"):
+                        with patch.object(Progress, "update"):
                             # Create real ProgressManager with Rich components
                             manager = ProgressManager(enabled=True)
                             tracker = manager.create_submission_progress()
-                            
+
                             # Should work with actual Rich integration
                             with tracker.track_submission(10, 1) as context:
                                 context.complete_collection(10)

--- a/tests/unit/test_retry_manager.py
+++ b/tests/unit/test_retry_manager.py
@@ -1,8 +1,7 @@
 """Comprehensive tests for the retry manager and error recovery system."""
 
-import asyncio
 import time
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
@@ -30,11 +29,7 @@ class TestRetryManager:
     def test_retry_manager_custom_initialization(self):
         """Test RetryManager with custom parameters."""
         manager = RetryManager(
-            max_retries=5,
-            base_delay=2.0,
-            max_delay=120.0,
-            exponential_base=1.5,
-            jitter=False
+            max_retries=5, base_delay=2.0, max_delay=120.0, exponential_base=1.5, jitter=False
         )
         assert manager.max_retries == 5
         assert manager.base_delay == 2.0
@@ -46,27 +41,26 @@ class TestRetryManager:
         """Test RetryManager with custom exception sets."""
         custom_retryable = {ValueError, TypeError}
         custom_non_retryable = {KeyError, AttributeError}
-        
+
         manager = RetryManager(
-            retryable_exceptions=custom_retryable,
-            non_retryable_exceptions=custom_non_retryable
+            retryable_exceptions=custom_retryable, non_retryable_exceptions=custom_non_retryable
         )
-        
+
         assert manager.retryable_exceptions == custom_retryable
         assert manager.non_retryable_exceptions == custom_non_retryable
 
     def test_calculate_delay_basic(self):
         """Test basic delay calculation."""
         manager = RetryManager(base_delay=2.0, exponential_base=2.0, jitter=False)
-        
+
         # First retry (attempt 0)
         delay = manager.calculate_delay(0)
         assert delay == 2.0
-        
+
         # Second retry (attempt 1)
         delay = manager.calculate_delay(1)
         assert delay == 4.0
-        
+
         # Third retry (attempt 2)
         delay = manager.calculate_delay(2)
         assert delay == 8.0
@@ -74,7 +68,7 @@ class TestRetryManager:
     def test_calculate_delay_with_max(self):
         """Test delay calculation with maximum limit."""
         manager = RetryManager(base_delay=10.0, max_delay=15.0, jitter=False)
-        
+
         # Should be capped at max_delay
         delay = manager.calculate_delay(5)  # Would be 320.0 without cap
         assert delay == 15.0
@@ -82,7 +76,7 @@ class TestRetryManager:
     def test_calculate_delay_with_retry_after(self):
         """Test delay calculation with retry-after header."""
         manager = RetryManager(base_delay=2.0, jitter=False)
-        
+
         # Should use retry_after value instead of calculated delay
         delay = manager.calculate_delay(0, retry_after=5.0)
         assert delay == 5.0
@@ -90,10 +84,10 @@ class TestRetryManager:
     def test_calculate_delay_with_jitter(self):
         """Test delay calculation with jitter enabled."""
         manager = RetryManager(base_delay=10.0, jitter=True)
-        
+
         # Run multiple times to verify jitter creates variation
         delays = [manager.calculate_delay(0) for _ in range(10)]
-        
+
         # All delays should be close to base_delay but not identical
         assert all(8.0 <= delay <= 12.0 for delay in delays)  # ±20% jitter range
         assert len(set(delays)) > 1  # Should have variation
@@ -101,12 +95,12 @@ class TestRetryManager:
     def test_is_retryable_default_exceptions(self):
         """Test exception classification with default settings."""
         manager = RetryManager()
-        
+
         # Retryable exceptions
         assert manager.is_retryable(ConnectionError("Network error"))
         assert manager.is_retryable(TimeoutError("Request timeout"))
         assert manager.is_retryable(RetryableError("Custom retryable"))
-        
+
         # Non-retryable exceptions
         assert not manager.is_retryable(ValueError("Invalid input"))
         assert not manager.is_retryable(TypeError("Type error"))
@@ -115,20 +109,19 @@ class TestRetryManager:
     def test_is_retryable_custom_exceptions(self):
         """Test exception classification with custom settings."""
         manager = RetryManager(
-            retryable_exceptions={ValueError},
-            non_retryable_exceptions={ConnectionError}
+            retryable_exceptions={ValueError}, non_retryable_exceptions={ConnectionError}
         )
-        
+
         # Custom retryable
         assert manager.is_retryable(ValueError("Now retryable"))
-        
+
         # Custom non-retryable
         assert not manager.is_retryable(ConnectionError("Now non-retryable"))
 
     def test_extract_retry_after_none(self):
         """Test retry-after extraction when not available."""
         manager = RetryManager()
-        
+
         # Standard exceptions without retry-after
         assert manager.extract_retry_after(ValueError("Error")) is None
         assert manager.extract_retry_after(ConnectionError("Error")) is None
@@ -136,21 +129,21 @@ class TestRetryManager:
     def test_extract_retry_after_http_exception(self):
         """Test retry-after extraction from HTTP-like exceptions."""
         manager = RetryManager()
-        
+
         # Mock HTTP exception with response
         class MockHTTPError(Exception):
             def __init__(self, response):
                 self.response = response
-        
+
         class MockResponse:
             def __init__(self, headers):
                 self.headers = headers
-        
+
         # With retry-after header
         response = MockResponse({"retry-after": "30"})
         exception = MockHTTPError(response)
         assert manager.extract_retry_after(exception) == 30.0
-        
+
         # Without retry-after header
         response = MockResponse({})
         exception = MockHTTPError(response)
@@ -159,85 +152,83 @@ class TestRetryManager:
     def test_execute_with_retry_success_immediately(self):
         """Test successful execution without retries."""
         manager = RetryManager()
-        
+
         def successful_function():
             return "success"
-        
+
         result = manager.execute_with_retry(successful_function)
         assert result == "success"
 
     def test_execute_with_retry_success_after_retries(self):
         """Test successful execution after some failures."""
         manager = RetryManager(base_delay=0.01)  # Fast retries for testing
-        
+
         call_count = 0
+
         def function_with_transient_failures():
             nonlocal call_count
             call_count += 1
             if call_count < 3:
                 raise ConnectionError("Transient error")
             return "success"
-        
-        with patch('time.sleep'):  # Mock sleep to speed up test
+
+        with patch("time.sleep"):  # Mock sleep to speed up test
             result = manager.execute_with_retry(function_with_transient_failures)
-        
+
         assert result == "success"
         assert call_count == 3
 
     def test_execute_with_retry_exhausted(self):
         """Test retry exhaustion with persistent failures."""
         manager = RetryManager(max_retries=2, base_delay=0.01)
-        
+
         call_count = 0
+
         def always_failing_function():
             nonlocal call_count
             call_count += 1
             raise ConnectionError("Persistent error")
-        
-        with patch('time.sleep'):  # Mock sleep to speed up test
+
+        with patch("time.sleep"):  # Mock sleep to speed up test
             with pytest.raises(ConnectionError):
                 manager.execute_with_retry(always_failing_function)
-        
+
         assert call_count == 3  # Initial + 2 retries
 
     def test_execute_with_retry_non_retryable(self):
         """Test immediate failure for non-retryable exceptions."""
         manager = RetryManager()
-        
+
         call_count = 0
+
         def function_with_non_retryable_error():
             nonlocal call_count
             call_count += 1
             raise ValueError("Non-retryable error")
-        
+
         with pytest.raises(ValueError):
             manager.execute_with_retry(function_with_non_retryable_error)
-        
+
         assert call_count == 1  # Should not retry
 
     def test_execute_with_retry_with_args_kwargs(self):
         """Test retry execution with function arguments."""
         manager = RetryManager()
-        
+
         def function_with_args(arg1, arg2, kwarg1=None):
             return f"{arg1}-{arg2}-{kwarg1}"
-        
-        result = manager.execute_with_retry(
-            function_with_args,
-            "test",
-            "value",
-            kwarg1="keyword"
-        )
+
+        result = manager.execute_with_retry(function_with_args, "test", "value", kwarg1="keyword")
         assert result == "test-value-keyword"
 
     @pytest.mark.asyncio
     async def test_execute_with_retry_async_success(self):
         """Test async retry execution with immediate success."""
         manager = RetryManager()
-        
+
         async def async_successful_function():
             return "async_success"
-        
+
         result = await manager.execute_with_retry_async(async_successful_function)
         assert result == "async_success"
 
@@ -245,18 +236,19 @@ class TestRetryManager:
     async def test_execute_with_retry_async_with_retries(self):
         """Test async retry execution with eventual success."""
         manager = RetryManager(base_delay=0.01)
-        
+
         call_count = 0
+
         async def async_function_with_failures():
             nonlocal call_count
             call_count += 1
             if call_count < 3:
                 raise ConnectionError("Async transient error")
             return "async_success"
-        
-        with patch('asyncio.sleep', new_callable=AsyncMock):  # Mock async sleep
+
+        with patch("asyncio.sleep", new_callable=AsyncMock):  # Mock async sleep
             result = await manager.execute_with_retry_async(async_function_with_failures)
-        
+
         assert result == "async_success"
         assert call_count == 3
 
@@ -264,17 +256,18 @@ class TestRetryManager:
     async def test_execute_with_retry_async_exhausted(self):
         """Test async retry exhaustion."""
         manager = RetryManager(max_retries=1, base_delay=0.01)
-        
+
         call_count = 0
+
         async def always_failing_async_function():
             nonlocal call_count
             call_count += 1
             raise ConnectionError("Persistent async error")
-        
-        with patch('asyncio.sleep', new_callable=AsyncMock):
+
+        with patch("asyncio.sleep", new_callable=AsyncMock):
             with pytest.raises(ConnectionError):
                 await manager.execute_with_retry_async(always_failing_async_function)
-        
+
         assert call_count == 2  # Initial + 1 retry
 
 
@@ -284,7 +277,7 @@ class TestRetryDecorators:
     def test_with_retry_decorator_default(self):
         """Test @with_retry decorator with default settings."""
         call_count = 0
-        
+
         @with_retry()
         def decorated_function():
             nonlocal call_count
@@ -292,45 +285,47 @@ class TestRetryDecorators:
             if call_count < 3:
                 raise ConnectionError("Retryable error")
             return "decorated_success"
-        
-        with patch('time.sleep'):  # Mock sleep
+
+        with patch("time.sleep"):  # Mock sleep
             result = decorated_function()
-        
+
         assert result == "decorated_success"
         assert call_count == 3
 
     def test_with_retry_decorator_custom_params(self):
         """Test @with_retry decorator with custom parameters."""
         call_count = 0
-        
+
         @with_retry(max_retries=1, base_delay=0.01)
         def decorated_function():
             nonlocal call_count
             call_count += 1
             raise ConnectionError("Always fails")
-        
-        with patch('time.sleep'):
+
+        with patch("time.sleep"):
             with pytest.raises(ConnectionError):
                 decorated_function()
-        
+
         assert call_count == 2  # Initial + 1 retry
 
     def test_with_retry_decorator_preserves_metadata(self):
         """Test that decorator preserves function metadata."""
+
         @with_retry()
         def original_function():
             """Original docstring."""
             return "result"
-        
+
         assert original_function.__name__ == "original_function"
         assert original_function.__doc__ == "Original docstring."
 
     def test_with_retry_decorator_with_args(self):
         """Test decorator with function arguments."""
+
         @with_retry()
         def function_with_args(x, y, multiplier=1):
             return (x + y) * multiplier
-        
+
         result = function_with_args(2, 3, multiplier=4)
         assert result == 20
 
@@ -338,7 +333,7 @@ class TestRetryDecorators:
     async def test_with_retry_async_decorator(self):
         """Test @with_retry_async decorator."""
         call_count = 0
-        
+
         @with_retry_async(base_delay=0.01)
         async def async_decorated_function():
             nonlocal call_count
@@ -346,21 +341,22 @@ class TestRetryDecorators:
             if call_count < 2:
                 raise ConnectionError("Async retryable error")
             return "async_decorated_success"
-        
-        with patch('asyncio.sleep', new_callable=AsyncMock):
+
+        with patch("asyncio.sleep", new_callable=AsyncMock):
             result = await async_decorated_function()
-        
+
         assert result == "async_decorated_success"
         assert call_count == 2
 
     @pytest.mark.asyncio
     async def test_with_retry_async_decorator_preserves_metadata(self):
         """Test that async decorator preserves function metadata."""
+
         @with_retry_async()
         async def async_original_function():
             """Async original docstring."""
             return "async_result"
-        
+
         assert async_original_function.__name__ == "async_original_function"
         assert async_original_function.__doc__ == "Async original docstring."
 
@@ -371,7 +367,7 @@ class TestCreateRetryManager:
     def test_create_retry_manager_no_settings(self):
         """Test creating retry manager without settings."""
         manager = create_retry_manager()
-        
+
         # Should use defaults
         assert manager.max_retries == 3
         assert manager.base_delay == 1.0
@@ -386,11 +382,11 @@ class TestCreateRetryManager:
             "base_delay": 2.0,
             "max_delay": 120.0,
             "exponential_base": 1.5,
-            "jitter": False
+            "jitter": False,
         }
-        
+
         manager = create_retry_manager(settings)
-        
+
         assert manager.max_retries == 5
         assert manager.base_delay == 2.0
         assert manager.max_delay == 120.0
@@ -401,12 +397,12 @@ class TestCreateRetryManager:
         """Test creating retry manager with partial settings."""
         settings = {
             "max_retries": 10,
-            "base_delay": 3.0
+            "base_delay": 3.0,
             # Other settings should use defaults
         }
-        
+
         manager = create_retry_manager(settings)
-        
+
         assert manager.max_retries == 10
         assert manager.base_delay == 3.0
         assert manager.max_delay == 60.0  # Default
@@ -420,53 +416,55 @@ class TestRetryManagerWithRealWorld:
     def test_http_timeout_scenario(self):
         """Test retry behavior for HTTP timeout scenarios."""
         manager = RetryManager(max_retries=3, base_delay=0.01)
-        
+
         call_count = 0
+
         def simulate_http_request():
             nonlocal call_count
             call_count += 1
             if call_count <= 2:
                 raise TimeoutError("HTTP request timeout")
             return {"status": "success", "data": "response"}
-        
-        with patch('time.sleep'):
+
+        with patch("time.sleep"):
             result = simulate_http_request()
             # First call would succeed without retry manager
             assert result == {"status": "success", "data": "response"}
-        
+
         # Reset and test with retry manager
         call_count = 0
-        with patch('time.sleep'):
+        with patch("time.sleep"):
             result = manager.execute_with_retry(simulate_http_request)
-        
+
         assert result == {"status": "success", "data": "response"}
         assert call_count == 3  # Succeeded on third attempt
 
     def test_api_rate_limiting_scenario(self):
         """Test retry behavior for API rate limiting."""
         manager = RetryManager(max_retries=2, base_delay=0.01)
-        
+
         class RateLimitError(Exception):
             def __init__(self, retry_after):
-                self.response = type('obj', (object,), {
-                    'headers': {'retry-after': str(retry_after)}
-                })
+                self.response = type(
+                    "obj", (object,), {"headers": {"retry-after": str(retry_after)}}
+                )
                 super().__init__("Rate limited")
-        
+
         call_count = 0
+
         def rate_limited_api_call():
             nonlocal call_count
             call_count += 1
             if call_count == 1:
                 raise RateLimitError(5)  # Rate limited, retry after 5 seconds
             return {"data": "api_response"}
-        
+
         # Add RateLimitError to retryable exceptions
         manager.retryable_exceptions.add(RateLimitError)
-        
-        with patch('time.sleep') as mock_sleep:
+
+        with patch("time.sleep") as mock_sleep:
             result = manager.execute_with_retry(rate_limited_api_call)
-        
+
         assert result == {"data": "api_response"}
         assert call_count == 2
         # Should have used retry-after delay
@@ -475,15 +473,16 @@ class TestRetryManagerWithRealWorld:
     def test_network_connection_recovery(self):
         """Test retry behavior for network connection issues."""
         manager = RetryManager(max_retries=4, base_delay=0.01)
-        
+
         network_errors = [
             ConnectionError("Connection refused"),
             OSError("Network unreachable"),
             TimeoutError("Connection timeout"),
-            ConnectionError("Connection reset")
+            ConnectionError("Connection reset"),
         ]
-        
+
         call_count = 0
+
         def unreliable_network_call():
             nonlocal call_count
             if call_count < len(network_errors):
@@ -492,23 +491,24 @@ class TestRetryManagerWithRealWorld:
                 raise error
             call_count += 1
             return "network_success"
-        
-        with patch('time.sleep'):
+
+        with patch("time.sleep"):
             result = manager.execute_with_retry(unreliable_network_call)
-        
+
         assert result == "network_success"
         assert call_count == 5  # 4 failures + 1 success
 
     def test_mixed_error_types(self):
         """Test handling mixed retryable and non-retryable errors."""
         manager = RetryManager(max_retries=3, base_delay=0.01)
-        
+
         errors = [
             ConnectionError("Retryable"),
-            ValueError("Non-retryable")  # Should stop here
+            ValueError("Non-retryable"),  # Should stop here
         ]
-        
+
         call_count = 0
+
         def mixed_error_function():
             nonlocal call_count
             if call_count < len(errors):
@@ -516,25 +516,25 @@ class TestRetryManagerWithRealWorld:
                 call_count += 1
                 raise error
             return "should_not_reach"
-        
-        with patch('time.sleep'):
+
+        with patch("time.sleep"):
             with pytest.raises(ValueError):
                 manager.execute_with_retry(mixed_error_function)
-        
+
         assert call_count == 2  # Should stop at ValueError
 
     def test_performance_under_load(self):
         """Test retry manager performance with multiple operations."""
         manager = RetryManager(max_retries=1, base_delay=0.001)
-        
+
         def fast_operation(operation_id):
             if operation_id % 10 == 0:  # 10% failure rate
                 raise ConnectionError("Simulated failure")
             return f"result_{operation_id}"
-        
+
         start_time = time.time()
-        
-        with patch('time.sleep'):  # Remove actual delays
+
+        with patch("time.sleep"):  # Remove actual delays
             results = []
             for i in range(100):
                 try:
@@ -542,18 +542,18 @@ class TestRetryManagerWithRealWorld:
                     results.append(result)
                 except ConnectionError:
                     results.append(f"failed_{i}")
-        
+
         duration = time.time() - start_time
-        
+
         # Should complete quickly
         assert duration < 1.0
         assert len(results) == 100
-        
+
         # Check mix of successes and failures
         successes = [r for r in results if r.startswith("result_")]
         failures = [r for r in results if r.startswith("failed_")]
         assert len(successes) > 80  # Most should succeed
-        assert len(failures) > 0   # Some should fail
+        assert len(failures) > 0  # Some should fail
 
 
 class TestRetryManagerEdgeCases:
@@ -562,22 +562,23 @@ class TestRetryManagerEdgeCases:
     def test_zero_max_retries(self):
         """Test behavior with zero max retries."""
         manager = RetryManager(max_retries=0)
-        
+
         call_count = 0
+
         def failing_function():
             nonlocal call_count
             call_count += 1
             raise ConnectionError("Always fails")
-        
+
         with pytest.raises(ConnectionError):
             manager.execute_with_retry(failing_function)
-        
+
         assert call_count == 1  # No retries
 
     def test_negative_delays(self):
         """Test handling of negative delay values."""
         manager = RetryManager(base_delay=-1.0)
-        
+
         # Should handle negative delays gracefully
         delay = manager.calculate_delay(0)
         assert delay >= 0  # Should not be negative
@@ -587,20 +588,17 @@ class TestRetryManagerEdgeCases:
         manager = RetryManager(
             base_delay=1000.0,
             exponential_base=10.0,
-            max_delay=5.0  # Much smaller max
+            max_delay=5.0,  # Much smaller max
         )
-        
+
         # Should be capped at max_delay
         delay = manager.calculate_delay(10)
         assert delay == 5.0
 
     def test_empty_exception_sets(self):
         """Test behavior with empty exception sets."""
-        manager = RetryManager(
-            retryable_exceptions=set(),
-            non_retryable_exceptions=set()
-        )
-        
+        manager = RetryManager(retryable_exceptions=set(), non_retryable_exceptions=set())
+
         # No exceptions should be retryable
         assert not manager.is_retryable(ConnectionError("Error"))
         assert not manager.is_retryable(ValueError("Error"))
@@ -608,18 +606,19 @@ class TestRetryManagerEdgeCases:
     def test_function_returning_none(self):
         """Test retry with function returning None."""
         manager = RetryManager()
-        
+
         def function_returning_none():
             return None
-        
+
         result = manager.execute_with_retry(function_returning_none)
         assert result is None
 
     def test_function_with_exception_in_finally(self):
         """Test retry with function that has exception in finally block."""
         manager = RetryManager(max_retries=1, base_delay=0.01)
-        
+
         call_count = 0
+
         def function_with_finally_exception():
             nonlocal call_count
             call_count += 1
@@ -630,9 +629,9 @@ class TestRetryManagerEdgeCases:
             finally:
                 # This finally block should not interfere with retry logic
                 pass
-        
-        with patch('time.sleep'):
+
+        with patch("time.sleep"):
             result = manager.execute_with_retry(function_with_finally_exception)
-        
+
         assert result == "success"
         assert call_count == 2


### PR DESCRIPTION
## Summary
- cleanup unused variables in integration tests
- fix unused imports and sort import blocks across test suite
- apply ruff formatting to updated tests

## Testing
- `ruff check tests`
- `mypy src` *(fails: Name "version" already defined, unexpected keyword arguments, etc.)*
- `PYTHONPATH=src pytest -q tests/unit/test_basic_integrity.py::TestBasicIntegrity::test_display_help_message` *(fails: ModuleNotFoundError: No module named 'pydantic')*